### PR TITLE
SRE-853 Adds threads for each metric in collect function

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -27,3 +27,7 @@ class Cache():
         """Deletes a key from cache."""
         if self.is_cached(key):
             del self._cache[key]
+
+    def clear_cache(self):
+        """Clears the entire cache"""
+        self._cache.clear()

--- a/src/collectors.py
+++ b/src/collectors.py
@@ -106,12 +106,12 @@ class CardanoCollector():
 
     def alive(self):
         """Returns true if endpoint is alive, false if not."""
-        return self.websocket.query(self.block_height_payload,
-                                    skip_checks=True) is not None
+        return self.websocket.cached_query(self.block_height_payload,
+                                           skip_checks=True) is not None
 
     def block_height(self):
         """Returns latest block height."""
-        return self.websocket.query(self.block_height_payload, skip_checks=True)
+        return self.websocket.cached_query(self.block_height_payload, skip_checks=True)
 
     def invalidate_cache(self):
         """Clears the entire cache"""

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -2,8 +2,6 @@
 import asyncio
 import json
 import threading
-import base64
-
 from websockets.client import connect
 from websockets.exceptions import ConnectionClosed, WebSocketException
 import requests
@@ -65,7 +63,7 @@ class HttpsInterface():
                 return result
         return None
 
-    def cached_json_rpc_post(self, payload: dict, invalidate_cache=False):
+    def cached_json_rpc_post(self, payload: dict):
         """Calls json_rpc_post and stores the result in in-memory
         cache, by using payload as key.Method will always return
         cached value after the first call. Cache never expires."""
@@ -73,8 +71,6 @@ class HttpsInterface():
 
         if self.cache.is_cached(cache_key):
             return_value = self.cache.retrieve_key_value(cache_key)
-            if invalidate_cache:
-                self.cache.remove_key_from_cache(cache_key)
             return return_value
 
         value = self.json_rpc_post(payload)
@@ -198,15 +194,13 @@ class WebsocketInterface(WebsocketSubscription):  # pylint: disable=too-many-ins
         """Asyncio handler for _query method."""
         return asyncio.run(self._query(payload, skip_checks))
 
-    def cached_query(self, payload, skip_checks=False, invalidate_cache=False):
+    def cached_query(self, payload, skip_checks=False):
         """Calls json_rpc_post and stores the result in in-memory
         cache, by using payload as key.Method will always return
         cached value after the first call. Cache never expires."""
         cache_key = str(payload)
         if self.cache.is_cached(cache_key):
             value = self.cache.retrieve_key_value(cache_key)
-            if invalidate_cache:
-                self.cache.remove_key_from_cache(cache_key)
             return value
 
         value = self.query(payload, skip_checks)

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -67,6 +67,14 @@ class PrometheusCustomCollector():  # pylint: disable=too-few-public-methods
         self._collector_registry = CollectorRegistry().get_collector_registry
         self._metrics_loader = MetricsLoader()
 
+    def _write_metric(self, collector, metric, attribute):
+        """Gets metric from collector and writes it"""
+        if hasattr(collector, attribute):
+            metric_value = getattr(collector, attribute)()
+            print(metric_value)
+            if metric_value is not None:
+                metric.add_metric(collector.labels, metric_value)
+
     def collect(self):
         """This method is called each time /metric is called."""
         health_metric = self._metrics_loader.health_metric
@@ -75,52 +83,26 @@ class PrometheusCustomCollector():  # pylint: disable=too-few-public-methods
         block_height_metric = self._metrics_loader.block_height_metric
         client_version_metric = self._metrics_loader.client_version_metric
         total_difficulty_metric = self._metrics_loader.total_difficulty_metric
-       
-        def _write_metric(metric, metric_value):
-            if metric_value is not None:
-                metric.add_metric(collector.labels, metric_value)
-    
-        def _write_alive(collector):
-                _write_metric(health_metric, collector.alive())
 
-        def _write_disconnects(collector):
-            if hasattr(collector, 'disconnects'):
-                _write_metric(disconnects_metric, collector.disconnects())
-
-        def _write_heads_received(collector):
-            if hasattr(collector, 'heads_received'):
-                _write_metric(heads_received_metric, collector.heads_received())
-
-        def _write_block_height(collector):
-            if hasattr(collector, 'block_height'):
-                _write_metric(block_height_metric, collector.block_height())
-
-        def _write_client_version(collector):
-            if hasattr(collector, 'client_version'):
-                _write_metric(client_version_metric, collector.client_version())
-
-        def _write_total_difficulty(collector):
-            if hasattr(collector, 'total_difficulty'):
-                _write_metric(total_difficulty_metric, collector.total_difficulty())
-        
         # Make sure that multiplier is always number of metrics implemented.
         multiplier = 6
 
-        with ThreadPoolExecutor(        
-                max_workers=len(self._collector_registry)*multiplier) as executor:
+        with ThreadPoolExecutor(
+                max_workers=len(self._collector_registry) * multiplier) as executor:
             for collector in self._collector_registry:
-                #TODO: Make this work.
                 collector.interface.cache.clear_cache()
-                executor.submit(_write_alive, collector)
-                executor.submit(_write_disconnects, collector)
-                executor.submit(_write_heads_received, collector)
-                executor.submit(_write_block_height, collector)
-                executor.submit(_write_client_version, collector)
-                executor.submit(_write_total_difficulty, collector)
-                
-                
-
-                
+                executor.submit(self._write_metric, collector,
+                                health_metric, 'alive')
+                executor.submit(self._write_metric, collector,
+                                client_version_metric, 'client_version')
+                executor.submit(self._write_metric, collector,
+                                block_height_metric, 'block_height')
+                executor.submit(self._write_metric, collector,
+                                heads_received_metric, 'heads_received')
+                executor.submit(self._write_metric, collector,
+                                disconnects_metric, 'disconnects')
+                executor.submit(self._write_metric, collector,
+                                total_difficulty_metric, 'total_difficulty')
 
         yield health_metric
         yield heads_received_metric

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -66,12 +66,11 @@ class PrometheusCustomCollector():  # pylint: disable=too-few-public-methods
     def __init__(self):
         self._collector_registry = CollectorRegistry().get_collector_registry
         self._metrics_loader = MetricsLoader()
+        self._metric_names = ["alive", "disconnects", "heads_received",
+                              "block_height", "client_version", "total_difficulty"]
 
     def collect(self):
         """This method is called each time /metric is called."""
-
-        metric_names = ["alive", "disconnects", "heads_received",
-                        "block_height", "client_version", "total_difficulty"]
         health_metric = self._metrics_loader.health_metric
         heads_received_metric = self._metrics_loader.heads_received_metric
         disconnects_metric = self._metrics_loader.disconnects_metric
@@ -109,10 +108,10 @@ class PrometheusCustomCollector():  # pylint: disable=too-few-public-methods
             collector.invalidate_cache()
 
         with ThreadPoolExecutor(
-                max_workers=len(self._collector_registry) * len(metric_names)) as executor:
+                max_workers=len(self._collector_registry) * len(self._metric_names)) as executor:
             for collector in self._collector_registry:
                 futures_dict = {}
-                for metric_name in metric_names:
+                for metric_name in self._metric_names:
                     metric_call = getattr(collector, metric_name, None)
                     if metric_call is not None:
                         futures_dict[metric_name] = executor.submit(

--- a/src/test_cache.py
+++ b/src/test_cache.py
@@ -1,5 +1,5 @@
 """Test module for cache"""
-#pylint: disable=protected-access
+# pylint: disable=protected-access
 from unittest import TestCase
 from cache import Cache
 
@@ -39,3 +39,9 @@ class TestCache(TestCase):
         self.cache.store_key_value("key", "value")
         self.assertTrue(self.cache.is_cached("key"))
         self.assertFalse(self.cache.is_cached("wrongkey"))
+
+    def test_clear_cache(self):
+        """Tests that the cache attribute is cleared when the clear_cache method is called"""
+        self.cache._cache["dummy"] = "data"
+        self.cache.clear_cache()
+        self.assertTrue(len(self.cache._cache) == 0)

--- a/src/test_collectors.py
+++ b/src/test_collectors.py
@@ -28,6 +28,11 @@ class TestEvmCollector(TestCase):
         self.mocked_websocket.assert_called_once_with(
             self.url, self.sub_payload, **self.client_params)
 
+    def test_interface_attribute_exists(self):
+        """Tests that the interface attribute exists.
+        May be used by external calls to access objects such as the interface cache"""
+        self.assertTrue(hasattr(self.evm_collector, 'interface'))
+
     def test_websocket_attr_daemon_is_bool(self):
         """Tests that the daemon attribute is of type bool"""
         self.assertEqual(bool, type(self.mocked_websocket.return_value.daemon))
@@ -68,11 +73,6 @@ class TestEvmCollector(TestCase):
         self.mocked_websocket.return_value.cached_query.assert_called_once_with(
             payload)
 
-    def test_invalidate_cache(self):
-        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
-        self.evm_collector.invalidate_cache()
-        self.mocked_websocket.return_value.cache.clear_cache.assert_called_once_with()
-
 
 class TestConfluxCollector(TestCase):
     """Tests the conflux collector class"""
@@ -97,6 +97,11 @@ class TestConfluxCollector(TestCase):
         """Tests that the conflux collector calls the websocket interface with the correct args"""
         self.mocked_websocket.assert_called_once_with(
             self.url, self.sub_payload, **self.client_params)
+
+    def test_interface_attribute_exists(self):
+        """Tests that the interface attribute exists.
+        May be used by external calls to access objects such as the interface cache"""
+        self.assertTrue(hasattr(self.conflux_collector, 'interface'))
 
     def test_websocket_attr_daemon_is_bool(self):
         """Tests that the daemon attribute is of type bool"""
@@ -138,11 +143,6 @@ class TestConfluxCollector(TestCase):
         self.mocked_websocket.return_value.cached_query.assert_called_once_with(
             payload)
 
-    def test_invalidate_cache(self):
-        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
-        self.conflux_collector.invalidate_cache()
-        self.mocked_websocket.return_value.cache.clear_cache.assert_called_once_with()
-
 
 class TestCardanoCollector(TestCase):
     """Tests the cardano collector class"""
@@ -171,6 +171,11 @@ class TestCardanoCollector(TestCase):
         self.mocked_websocket.assert_called_once_with(
             self.url, **self.client_params)
 
+    def test_interface_attribute_exists(self):
+        """Tests that the interface attribute exists.
+        May be used by external calls to access objects such as the interface cache"""
+        self.assertTrue(hasattr(self.cardano_collector, 'interface'))
+
     def test_websocket_attr_daemon_is_none(self):
         """Tests that the daemon attribute is None"""
         self.assertEqual(None, self.mocked_websocket.return_value.daemon)
@@ -192,11 +197,6 @@ class TestCardanoCollector(TestCase):
         self.cardano_collector.block_height()
         self.mocked_websocket.return_value.cached_query.assert_called_once_with(
             self.block_height_payload, skip_checks=True)
-
-    def test_invalidate_cache(self):
-        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
-        self.cardano_collector.invalidate_cache()
-        self.mocked_websocket.return_value.cache.clear_cache.assert_called_once_with()
 
 
 class TestBitcoinCollector(TestCase):
@@ -238,6 +238,11 @@ class TestBitcoinCollector(TestCase):
         """Tests that the bitcoin collector calls the https interface with the correct args"""
         self.mocked_connection.assert_called_once_with(
             self.url, self.open_timeout, self.ping_timeout)
+
+    def test_interface_attribute_exists(self):
+        """Tests that the interface attribute exists.
+        May be used by external calls to access objects such as the interface cache"""
+        self.assertTrue(hasattr(self.bitcoin_collector, 'interface'))
 
     def test_alive_call(self):
         """Tests the alive function uses the correct call and args"""
@@ -329,11 +334,6 @@ class TestBitcoinCollector(TestCase):
         result = self.bitcoin_collector.client_version()
         self.assertEqual(None, result)
 
-    def test_invalidate_cache(self):
-        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
-        self.bitcoin_collector.invalidate_cache()
-        self.mocked_connection.return_value.cache.clear_cache.assert_called_once_with()
-
 
 class TestFilecoinCollector(TestCase):
     """Tests the filecoin collector class"""
@@ -373,6 +373,11 @@ class TestFilecoinCollector(TestCase):
         """Tests that the filecoin collector calls the https interface with the correct args"""
         self.mocked_connection.assert_called_once_with(
             self.url, self.open_timeout, self.ping_timeout)
+
+    def test_interface_attribute_exists(self):
+        """Tests that the interface attribute exists.
+        May be used by external calls to access objects such as the interface cache"""
+        self.assertTrue(hasattr(self.filecoin_collector, 'interface'))
 
     def test_alive_call(self):
         """Tests the alive function uses the correct call and args"""
@@ -438,11 +443,6 @@ class TestFilecoinCollector(TestCase):
         result = self.filecoin_collector.client_version()
         self.assertEqual(None, result)
 
-    def test_invalidate_cache(self):
-        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
-        self.filecoin_collector.invalidate_cache()
-        self.mocked_connection.return_value.cache.clear_cache.assert_called_once_with()
-
 
 class TestSolanaCollector(TestCase):
     """Tests the solana collector class"""
@@ -482,6 +482,11 @@ class TestSolanaCollector(TestCase):
         """Tests that the solana collector calls the https interface with the correct args"""
         self.mocked_connection.assert_called_once_with(
             self.url, self.open_timeout, self.ping_timeout)
+
+    def test_interface_attribute_exists(self):
+        """Tests that the interface attribute exists.
+        May be used by external calls to access objects such as the interface cache"""
+        self.assertTrue(hasattr(self.solana_collector, 'interface'))
 
     def test_alive_call(self):
         """Tests the alive function uses the correct call and args"""
@@ -533,11 +538,6 @@ class TestSolanaCollector(TestCase):
         result = self.solana_collector.client_version()
         self.assertEqual(None, result)
 
-    def test_invalidate_cache(self):
-        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
-        self.solana_collector.invalidate_cache()
-        self.mocked_connection.return_value.cache.clear_cache.assert_called_once_with()
-
 
 class TestStarkwareCollector(TestCase):
     """Tests the starkware collector class"""
@@ -565,6 +565,11 @@ class TestStarkwareCollector(TestCase):
         self.mocked_connection.assert_called_once_with(
             self.url, self.open_timeout, self.ping_timeout)
 
+    def test_interface_attribute_exists(self):
+        """Tests that the interface attribute exists.
+        May be used by external calls to access objects such as the interface cache"""
+        self.assertTrue(hasattr(self.starkware_collector, 'interface'))
+
     def test_alive_call(self):
         """Tests the alive function uses the correct call and args"""
         self.starkware_collector.alive()
@@ -588,8 +593,3 @@ class TestStarkwareCollector(TestCase):
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
         result = self.starkware_collector.block_height()
         self.assertEqual(None, result)
-
-    def test_invalidate_cache(self):
-        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
-        self.starkware_collector.invalidate_cache()
-        self.mocked_connection.return_value.cache.clear_cache.assert_called_once_with()

--- a/src/test_collectors.py
+++ b/src/test_collectors.py
@@ -43,16 +43,16 @@ class TestEvmCollector(TestCase):
     def test_alive_is_true(self):
         """Tests the alive function returns true when websocket.healthy is true"""
         self.mocked_websocket.return_value.healthy = True
-        self.assertTrue(self.evm_collector.alive)
+        self.assertTrue(self.evm_collector.alive())
 
     def test_alive_is_false(self):
         """Tests the alive function returns false when websocket.healthy is false"""
         self.mocked_websocket.return_value.healthy = False
-        self.assertFalse(self.evm_collector.alive)
+        self.assertFalse(self.evm_collector.alive())
 
     def test_block_height(self):
         """Tests the block_height function uses the correct call and args to get block height"""
-        self.evm_collector.block_height  # pylint: disable=pointless-statement
+        self.evm_collector.block_height()
         self.mocked_websocket.return_value.get_message_property_to_hex.assert_called_once_with(
             'number')
 
@@ -64,9 +64,14 @@ class TestEvmCollector(TestCase):
             "params": [],
             "id": self.chain_id
         }
-        self.evm_collector.client_version  # pylint: disable=pointless-statement
+        self.evm_collector.client_version()
         self.mocked_websocket.return_value.cached_query.assert_called_once_with(
             payload)
+
+    def test_invalidate_cache(self):
+        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
+        self.evm_collector.invalidate_cache()
+        self.mocked_websocket.return_value.cache.clear_cache.assert_called_once_with()
 
 
 class TestConfluxCollector(TestCase):
@@ -108,16 +113,16 @@ class TestConfluxCollector(TestCase):
     def test_alive_is_true(self):
         """Tests the alive function returns true when websocket.healthy is true"""
         self.mocked_websocket.return_value.healthy = True
-        self.assertTrue(self.conflux_collector.alive)
+        self.assertTrue(self.conflux_collector.alive())
 
     def test_alive_is_false(self):
         """Tests the alive function returns false when websocket.healthy is false"""
         self.mocked_websocket.return_value.healthy = False
-        self.assertFalse(self.conflux_collector.alive)
+        self.assertFalse(self.conflux_collector.alive())
 
     def test_block_height(self):
         """Tests the block_height function uses the correct call and args to get block height"""
-        self.conflux_collector.block_height  # pylint: disable=pointless-statement
+        self.conflux_collector.block_height()
         self.mocked_websocket.return_value.get_message_property_to_hex.assert_called_once_with(
             'height')
 
@@ -129,9 +134,14 @@ class TestConfluxCollector(TestCase):
             "params": [],
             "id": self.chain_id
         }
-        self.conflux_collector.client_version  # pylint: disable=pointless-statement
+        self.conflux_collector.client_version()
         self.mocked_websocket.return_value.cached_query.assert_called_once_with(
             payload)
+
+    def test_invalidate_cache(self):
+        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
+        self.conflux_collector.invalidate_cache()
+        self.mocked_websocket.return_value.cache.clear_cache.assert_called_once_with()
 
 
 class TestCardanoCollector(TestCase):
@@ -167,21 +177,26 @@ class TestCardanoCollector(TestCase):
 
     def test_alive_call(self):
         """Tests the alive function uses the correct call and args"""
-        self.cardano_collector.alive  # pylint: disable=pointless-statement
+        self.cardano_collector.alive()
         self.mocked_websocket.return_value.cached_query.assert_called_once_with(
             self.block_height_payload, skip_checks=True)
 
     def test_alive_false(self):
         """Tests the alive function returns false when query returns None"""
         self.mocked_websocket.return_value.cached_query.return_value = None
-        result = self.cardano_collector.alive
+        result = self.cardano_collector.alive()
         self.assertFalse(result)
 
     def test_block_height(self):
         """Tests the block_height function uses the correct call and args to get block height"""
-        self.cardano_collector.block_height  # pylint: disable=pointless-statement
-        self.mocked_websocket.return_value.query.assert_called_once_with(
+        self.cardano_collector.block_height()
+        self.mocked_websocket.return_value.cached_query.assert_called_once_with(
             self.block_height_payload, skip_checks=True)
+
+    def test_invalidate_cache(self):
+        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
+        self.cardano_collector.invalidate_cache()
+        self.mocked_websocket.return_value.cache.clear_cache.assert_called_once_with()
 
 
 class TestBitcoinCollector(TestCase):
@@ -226,19 +241,19 @@ class TestBitcoinCollector(TestCase):
 
     def test_alive_call(self):
         """Tests the alive function uses the correct call and args"""
-        self.bitcoin_collector.alive  # pylint: disable=pointless-statement
+        self.bitcoin_collector.alive()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
             self.network_info_payload)
 
     def test_alive_false(self):
         """Tests the alive function returns false when post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.bitcoin_collector.alive
+        result = self.bitcoin_collector.alive()
         self.assertFalse(result)
 
     def test_block_height(self):
         """Tests the block_height function uses the correct call and args to get block height"""
-        self.bitcoin_collector.block_height  # pylint: disable=pointless-statement
+        self.bitcoin_collector.block_height()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
             self.blockchain_info_payload)
 
@@ -246,73 +261,78 @@ class TestBitcoinCollector(TestCase):
         """Tests that the block height is returned with the blocks key"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "blocks": 5}
-        result = self.bitcoin_collector.block_height
+        result = self.bitcoin_collector.block_height()
         self.assertEqual(5, result)
 
     def test_block_height_key_error_returns_none(self):
         """Tests that the block height returns None on KeyError"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "dummy_key": 5}
-        result = self.bitcoin_collector.block_height
+        result = self.bitcoin_collector.block_height()
         self.assertEqual(None, result)
 
     def test_block_height_returns_none(self):
         """Tests that the block height returns None if json_rpc_post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.bitcoin_collector.block_height
+        result = self.bitcoin_collector.block_height()
         self.assertEqual(None, result)
 
     def test_total_difficulty(self):
         """Tests the total_difficulty function uses the correct call and args to get difficulty"""
-        self.bitcoin_collector.total_difficulty  # pylint: disable=pointless-statement
+        self.bitcoin_collector.total_difficulty()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
-            self.blockchain_info_payload, invalidate_cache=True)
+            self.blockchain_info_payload)
 
     def test_total_difficulty_get_blocks_key(self):
         """Tests that the difficulty is returned with the difficulty key"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "difficulty": 5}
-        result = self.bitcoin_collector.total_difficulty
+        result = self.bitcoin_collector.total_difficulty()
         self.assertEqual(5, result)
 
     def test_total_difficulty_key_error_returns_none(self):
         """Tests that the total_difficulty returns None on KeyError"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "dummy_key": 5}
-        result = self.bitcoin_collector.total_difficulty
+        result = self.bitcoin_collector.total_difficulty()
         self.assertEqual(None, result)
 
     def test_total_difficulty_returns_none(self):
         """Tests that the total_difficulty returns None if json_rpc_post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.bitcoin_collector.total_difficulty
+        result = self.bitcoin_collector.total_difficulty()
         self.assertEqual(None, result)
 
     def test_client_version(self):
         """Tests the client_version function uses the correct call and args to get client version"""
-        self.bitcoin_collector.client_version  # pylint: disable=pointless-statement
+        self.bitcoin_collector.client_version()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
-            self.network_info_payload, invalidate_cache=True)
+            self.network_info_payload)
 
     def test_client_version_get_blocks_key(self):
         """Tests that the client version is returned as a string with the version key"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "version": 5}
-        result = self.bitcoin_collector.client_version
+        result = self.bitcoin_collector.client_version()
         self.assertEqual('5', result)
 
     def test_client_version_key_error_returns_none(self):
         """Tests that the client_version returns None on KeyError"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "dummy_key": 5}
-        result = self.bitcoin_collector.client_version
+        result = self.bitcoin_collector.client_version()
         self.assertEqual(None, result)
 
     def test_client_version_returns_none(self):
         """Tests that the client_version returns None if json_rpc_post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.bitcoin_collector.client_version
+        result = self.bitcoin_collector.client_version()
         self.assertEqual(None, result)
+
+    def test_invalidate_cache(self):
+        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
+        self.bitcoin_collector.invalidate_cache()
+        self.mocked_connection.return_value.cache.clear_cache.assert_called_once_with()
 
 
 class TestFilecoinCollector(TestCase):
@@ -356,19 +376,19 @@ class TestFilecoinCollector(TestCase):
 
     def test_alive_call(self):
         """Tests the alive function uses the correct call and args"""
-        self.filecoin_collector.alive  # pylint: disable=pointless-statement
+        self.filecoin_collector.alive()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
             self.client_version_payload)
 
     def test_alive_false(self):
         """Tests the alive function returns false when post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.filecoin_collector.alive
+        result = self.filecoin_collector.alive()
         self.assertFalse(result)
 
     def test_block_height(self):
         """Tests the block_height function uses the correct call and args to get block height"""
-        self.filecoin_collector.block_height  # pylint: disable=pointless-statement
+        self.filecoin_collector.block_height()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
             self.block_height_payload)
 
@@ -376,47 +396,52 @@ class TestFilecoinCollector(TestCase):
         """Tests that the block height is returned with the Height key"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "Height": 5}
-        result = self.filecoin_collector.block_height
+        result = self.filecoin_collector.block_height()
         self.assertEqual(5, result)
 
     def test_block_height_key_error_returns_none(self):
         """Tests that the block height returns None on KeyError"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "dummy_key": 5}
-        result = self.filecoin_collector.block_height
+        result = self.filecoin_collector.block_height()
         self.assertEqual(None, result)
 
     def test_block_height_returns_none(self):
         """Tests that the block height returns None if json_rpc_post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.filecoin_collector.block_height
+        result = self.filecoin_collector.block_height()
         self.assertEqual(None, result)
 
     def test_client_version(self):
         """Tests the client_version function uses the correct call and args to get client version"""
-        self.filecoin_collector.client_version  # pylint: disable=pointless-statement
+        self.filecoin_collector.client_version()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
-            self.client_version_payload, invalidate_cache=True)
+            self.client_version_payload)
 
     def test_client_version_get_blocks_key(self):
         """Tests that the client version is returned as a string with the version key"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "Version": 5}
-        result = self.filecoin_collector.client_version
+        result = self.filecoin_collector.client_version()
         self.assertEqual('5', result)
 
     def test_client_version_key_error_returns_none(self):
         """Tests that the client_version returns None on KeyError"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "dummy_key": 5}
-        result = self.filecoin_collector.client_version
+        result = self.filecoin_collector.client_version()
         self.assertEqual(None, result)
 
     def test_client_version_returns_none(self):
         """Tests that the client_version returns None if json_rpc_post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.filecoin_collector.client_version
+        result = self.filecoin_collector.client_version()
         self.assertEqual(None, result)
+
+    def test_invalidate_cache(self):
+        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
+        self.filecoin_collector.invalidate_cache()
+        self.mocked_connection.return_value.cache.clear_cache.assert_called_once_with()
 
 
 class TestSolanaCollector(TestCase):
@@ -460,53 +485,58 @@ class TestSolanaCollector(TestCase):
 
     def test_alive_call(self):
         """Tests the alive function uses the correct call and args"""
-        self.solana_collector.alive  # pylint: disable=pointless-statement
+        self.solana_collector.alive()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
             self.client_version_payload)
 
     def test_alive_false(self):
         """Tests the alive function returns false when post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.solana_collector.alive
+        result = self.solana_collector.alive()
         self.assertFalse(result)
 
     def test_block_height(self):
         """Tests the block_height function uses the correct call and args to get block height"""
-        self.solana_collector.block_height  # pylint: disable=pointless-statement
+        self.solana_collector.block_height()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
             self.block_height_payload)
 
     def test_block_height_returns_none(self):
         """Tests that the block height returns None if json_rpc_post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.solana_collector.block_height
+        result = self.solana_collector.block_height()
         self.assertEqual(None, result)
 
     def test_client_version(self):
         """Tests the client_version function uses the correct call and args to get client version"""
-        self.solana_collector.client_version  # pylint: disable=pointless-statement
+        self.solana_collector.client_version()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
-            self.client_version_payload, invalidate_cache=True)
+            self.client_version_payload)
 
     def test_client_version_get_blocks_key(self):
         """Tests that the client version is returned as a string with the solana-core key"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "solana-core": 5}
-        result = self.solana_collector.client_version
+        result = self.solana_collector.client_version()
         self.assertEqual('5', result)
 
     def test_client_version_key_error_returns_none(self):
         """Tests that the client_version returns None on KeyError"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = {
             "dummy_key": 5}
-        result = self.solana_collector.client_version
+        result = self.solana_collector.client_version()
         self.assertEqual(None, result)
 
     def test_client_version_returns_none(self):
         """Tests that the client_version returns None if json_rpc_post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.solana_collector.client_version
+        result = self.solana_collector.client_version()
         self.assertEqual(None, result)
+
+    def test_invalidate_cache(self):
+        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
+        self.solana_collector.invalidate_cache()
+        self.mocked_connection.return_value.cache.clear_cache.assert_called_once_with()
 
 
 class TestStarkwareCollector(TestCase):
@@ -537,24 +567,29 @@ class TestStarkwareCollector(TestCase):
 
     def test_alive_call(self):
         """Tests the alive function uses the correct call and args"""
-        self.starkware_collector.alive  # pylint: disable=pointless-statement
+        self.starkware_collector.alive()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
             self.block_height_payload)
 
     def test_alive_false(self):
         """Tests the alive function returns false when post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.starkware_collector.alive
+        result = self.starkware_collector.alive()
         self.assertFalse(result)
 
     def test_block_height(self):
         """Tests the block_height function uses the correct call and args to get block height"""
-        self.starkware_collector.block_height  # pylint: disable=pointless-statement
+        self.starkware_collector.block_height()
         self.mocked_connection.return_value.cached_json_rpc_post.assert_called_once_with(
-            self.block_height_payload, invalidate_cache=True)
+            self.block_height_payload)
 
     def test_block_height_returns_none(self):
         """Tests that the block height returns None if json_rpc_post returns None"""
         self.mocked_connection.return_value.cached_json_rpc_post.return_value = None
-        result = self.starkware_collector.block_height
+        result = self.starkware_collector.block_height()
         self.assertEqual(None, result)
+
+    def test_invalidate_cache(self):
+        """Tests that the invalidate_cache method calls clear_cache method in cache attribute"""
+        self.starkware_collector.invalidate_cache()
+        self.mocked_connection.return_value.cache.clear_cache.assert_called_once_with()

--- a/src/test_interfaces.py
+++ b/src/test_interfaces.py
@@ -191,14 +191,6 @@ class TestWebSocketInterface(IsolatedAsyncioTestCase):
             result = self.web_sock_interface.cached_query('key')
             self.assertEqual('value', result)
 
-    def test_cache_query_invalidate_cache(self):
-        """Tests that the cache is invalidated"""
-        with mock.patch('interfaces.Cache', autospec=True) as mocked_cache:
-            mocked_cache.is_cached.return_value = True
-            self.web_sock_interface.cache = mocked_cache
-            self.web_sock_interface.cached_query('key', False, True)
-            mocked_cache.remove_key_from_cache.assert_called_once_with('key')
-
     def test_cache_query_retrieve_invalid_key(self):
         """Tests that the query method is called for a key not in the cache"""
         with mock.patch('interfaces.WebsocketInterface.query') as mocked_query:

--- a/src/test_metrics.py
+++ b/src/test_metrics.py
@@ -1,0 +1,144 @@
+"""Tests the metrics module"""
+from unittest import TestCase, mock
+from prometheus_client.metrics_core import GaugeMetricFamily, CounterMetricFamily, InfoMetricFamily
+
+from metrics import MetricsLoader, PrometheusCustomCollector
+
+
+class TestMetricsLoader(TestCase):
+    """Tests the MetricsLoader class"""
+
+    def setUp(self):
+        self.metrics_loader = MetricsLoader()
+        self.labels = [
+            'url', 'provider', 'blockchain', 'network_name', 'network_type', 'chain_id'
+        ]
+
+    def test_labels(self):
+        """Tests that the metrics labels are set with correct naming and order"""
+        self.assertEqual(
+            self.labels, self.metrics_loader._labels)  # pylint: disable=protected-access
+
+    def test_health_metric(self):
+        """Tests the health_metric property calls GaugeMetric with the correct args"""
+        with mock.patch('metrics.GaugeMetricFamily') as gauge_mock:
+            self.metrics_loader.health_metric  # pylint: disable=pointless-statement
+            gauge_mock.assert_called_once_with(
+                'brpc_health',
+                'Returns 1 if rpc websocket server established a connection with the probe client.',
+                labels=self.labels)
+
+    def test_health_metric_returns_gauge(self):
+        """Tests the health_metric property returns a gauge"""
+        self.assertEqual(GaugeMetricFamily, type(
+            self.metrics_loader.health_metric))
+
+    def test_heads_received_metric(self):
+        """Tests the heads_received_metric property calls CounterMetric with the correct args"""
+        with mock.patch('metrics.CounterMetricFamily') as counter_mock:
+            self.metrics_loader.heads_received_metric  # pylint: disable=pointless-statement
+            counter_mock.assert_called_once_with(
+                'brpc_head_count',
+                'Heads received total.',
+                labels=self.labels)
+
+    def test_heads_received_metric_returns_counter(self):
+        """Tests the heads_received_metric property returns a counter"""
+        self.assertEqual(CounterMetricFamily, type(
+            self.metrics_loader.heads_received_metric))
+
+    def test_disconnects_metric(self):
+        """Tests the disconnects_metric property calls GaugeMetric with the correct args"""
+        with mock.patch('metrics.GaugeMetricFamily') as gauge_mock:
+            self.metrics_loader.disconnects_metric  # pylint: disable=pointless-statement
+            gauge_mock.assert_called_once_with(
+                'brpc_disconnects',
+                'How many times rpc has disconnected.',
+                labels=self.labels)
+
+    def test_disconnects_metric_returns_gauge(self):
+        """Tests the disconnects_metric property returns a gauge"""
+        self.assertEqual(GaugeMetricFamily, type(
+            self.metrics_loader.disconnects_metric))
+
+    def test_block_height_metric(self):
+        """Tests the block_height_metric property calls GaugeMetric with the correct args"""
+        with mock.patch('metrics.GaugeMetricFamily') as gauge_mock:
+            self.metrics_loader.block_height_metric  # pylint: disable=pointless-statement
+            gauge_mock.assert_called_once_with(
+                'brpc_block_height',
+                'Latest observed block_height.',
+                labels=self.labels)
+
+    def test_block_height_metric_returns_gauge(self):
+        """Tests the block_height_metric property returns a gauge"""
+        self.assertEqual(GaugeMetricFamily, type(
+            self.metrics_loader.block_height_metric))
+
+    def test_client_version_metric(self):
+        """Tests the client_version_metric property calls InfoMetric with the correct args"""
+        with mock.patch('metrics.InfoMetricFamily') as info_mock:
+            self.metrics_loader.client_version_metric  # pylint: disable=pointless-statement
+            info_mock.assert_called_once_with(
+                'brpc_client_version',
+                'Client version for the particular RPC endpoint.',
+                labels=self.labels)
+
+    def test_client_version_metric_returns_gauge(self):
+        """Tests the client_version_metric property returns a gauge"""
+        self.assertEqual(InfoMetricFamily, type(
+            self.metrics_loader.client_version_metric))
+
+    def test_total_difficulty_metric(self):
+        """Tests the total_difficulty_metric property calls GaugeMetric with the correct args"""
+        with mock.patch('metrics.GaugeMetricFamily') as gauge_mock:
+            self.metrics_loader.total_difficulty_metric  # pylint: disable=pointless-statement
+            gauge_mock.assert_called_once_with(
+                'brpc_total_difficulty',
+                'Total canonical chain difficulty observed from the first to the latest block.',
+                labels=self.labels)
+
+    def test_total_difficulty_metric_returns_gauge(self):
+        """Tests the total_difficulty_metric property returns a gauge"""
+        self.assertEqual(GaugeMetricFamily, type(
+            self.metrics_loader.total_difficulty_metric))
+
+
+class TestPrometheusCustomCollector(TestCase):
+    """Tests the prometheus custom collector class"""
+
+    def setUp(self):
+        with (
+            mock.patch("metrics.CollectorRegistry.get_collector_registry",
+                       new_callable=mock.PropertyMock(return_value=[mock.Mock()])) as mocked_registry,
+            mock.patch("metrics.MetricsLoader") as mocked_loader
+        ):
+            self.prom_collector = PrometheusCustomCollector()
+            self.mocked_registry = mocked_registry
+            self.mocked_loader = mocked_loader
+
+    def test_collect_metric_names(self):
+        """Tests that the collect method has the correct values in metric_names list"""
+        names = ["alive", "disconnects", "heads_received",
+                 "block_height", "client_version", "total_difficulty"]
+        self.assertEqual(
+            names, self.prom_collector._metric_names)  # pylint: disable=protected-access
+
+    def test_collect_yields_correct_metrics(self):
+        """Tests that the collect yields all the expected metrics"""
+        expected_returns = [
+            self.mocked_loader.return_value.health_metric,
+            self.mocked_loader.return_value.heads_received_metric,
+            self.mocked_loader.return_value.disconnects_metric,
+            self.mocked_loader.return_value.block_height_metric,
+            self.mocked_loader.return_value.client_version_metric,
+            self.mocked_loader.return_value.total_difficulty_metric
+        ]
+        results = self.prom_collector.collect()
+        for result in results:
+            self.assertTrue(result in expected_returns)
+
+    def test_collect_number_of_yields(self):
+        """Tests that the collect method yields the expected number of values"""
+        results = self.prom_collector.collect()
+        self.assertEqual(6, len(list(results)))

--- a/src/test_metrics.py
+++ b/src/test_metrics.py
@@ -109,10 +109,10 @@ class TestPrometheusCustomCollector(TestCase):
 
     def setUp(self):
         with (
-            mock.patch("metrics.CollectorRegistry.get_collector_registry",
-                       new_callable=mock.PropertyMock(return_value=[mock.Mock()])) as mocked_registry,
+            mock.patch("metrics.CollectorRegistry") as mocked_registry,
             mock.patch("metrics.MetricsLoader") as mocked_loader
         ):
+            mocked_registry.return_value.get_collector_registry = [mock.Mock()]
             self.prom_collector = PrometheusCustomCollector()
             self.mocked_registry = mocked_registry
             self.mocked_loader = mocked_loader


### PR DESCRIPTION
This allows each metric query to be handled by an independent thread which will speed up execution of the `/metrics` GET requests as they are IO bound network operations.

Also the cache was reworked to remove the need to execute the metric queries in a specific order.

Unit tests for these changes to follow soon.