### PR TITLE
update Cardano collector to work with ogmios API v6.1.x

### DIFF
--- a/src/collectors.py
+++ b/src/collectors.py
@@ -2,7 +2,6 @@
 from interfaces import WebsocketInterface, HttpsInterface
 from helpers import validate_dict_and_return_key_value, strip_url
 
-
 class EvmCollector():
     """A collector to fetch information about evm compatible RPC endpoints."""
 
@@ -116,13 +115,9 @@ class CardanoCollector():
         self.labels = labels
         self.chain_id = chain_id
         self.block_height_payload = {
-            "type": "jsonwsp/request",
-            "version": "1.0",
-            "servicename": "ogmios",
-            "methodname": "Query",
-            "args": {
-                "query": "blockHeight"
-            }
+            "id": "exporter",
+            "jsonrpc": "2.0",
+            "method": "queryNetwork/blockHeight"
         }
         self.interface = WebsocketInterface(
             url, **client_parameters)

--- a/src/test_collectors.py
+++ b/src/test_collectors.py
@@ -188,13 +188,9 @@ class TestCardanoCollector(TestCase):
         self.chain_id = 123
         self.client_params = {"param1": "dummy", "param2": "data"}
         self.block_height_payload = {
-            "type": "jsonwsp/request",
-            "version": "1.0",
-            "servicename": "ogmios",
-            "methodname": "Query",
-            "args": {
-                "query": "blockHeight"
-            }
+            "id": "exporter",
+            "jsonrpc": "2.0",
+            "method": "queryNetwork/blockHeight"
         }
         with mock.patch('collectors.WebsocketInterface') as mocked_websocket:
             self.cardano_collector = collectors.CardanoCollector(


### PR DESCRIPTION
**What**
1. Updating the Cardano collector to align with ogmios v6.1.x API:

Local testing output:
```
{"payload": {"id": "exporter", "jsonrpc": "2.0", "method": "queryNetwork/blockHeight"}, "component": "WebsocketInterface", "url": "https://an-rpc-provider.com/xxx", "event": "Querying endpoint.", "level": "debug"}
{"event": 10249117, "level": "info"}
```

**Why**
1. The current collector does not work with the version RPCs are now running and thus it fails to retrieve the block height correctly as expected 