### PR TITLE
Tron collector for Exporter

### DIFF
--- a/src/collectors.py
+++ b/src/collectors.py
@@ -427,13 +427,12 @@ class TronCollector():
             self.client_version_payload) is not None
 
     def block_height(self):
-        """Runs a cached query and returns blockheight after converting hex string value to an int"""
+        """Cached query and returns blockheight after converting hex string value to an int"""
         result = self.interface.cached_json_rpc_post(self.block_height_payload)
 
         if result and isinstance(result, str) and result.startswith('0x'):
             return int(result, 16)
-        else:
-            raise ValueError(f"Invalid block height result: {result}")
+        raise ValueError(f"Invalid block height result: {result}")
 
     def client_version(self):
         """Runs a cached query to return client version."""

--- a/src/collectors.py
+++ b/src/collectors.py
@@ -395,7 +395,7 @@ class AptosCollector():
         return self.interface.latest_query_latency
 
 class TronCollector():
-    """A collector to fetch information about Aptos endpoints."""
+    """A collector to fetch information from Tron endpoints."""
 
     def __init__(self, url, labels, chain_id, **client_parameters):
 

--- a/src/collectors.py
+++ b/src/collectors.py
@@ -427,7 +427,7 @@ class TronCollector():
             self.client_version_payload) is not None
 
     def block_height(self):
-        """Returns blockheight after converting string hexadecimal value to an int"""
+        """Runs a cached query and returns blockheight after converting hex string value to an int"""
         result = self.interface.cached_json_rpc_post(self.block_height_payload)
 
         if result and isinstance(result, str) and result.startswith('0x'):

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -47,7 +47,8 @@ class Config():
     def _load_configuration(self):
         allowed_providers = self._load_validation_file()
         supported_collectors = ('evm', 'cardano', 'conflux', 'solana',
-                                'bitcoin', 'doge', 'filecoin', 'starknet', 'aptos')
+                                'bitcoin', 'doge', 'filecoin', 'starknet', 'aptos',
+                                'tron')
 
         configuration_schema = Schema({
             'blockchain':

--- a/src/registries.py
+++ b/src/registries.py
@@ -83,6 +83,8 @@ class CollectorRegistry(EndpointRegistry):
                     collector = collectors.StarknetCollector
                 case "aptos", "aptos":
                     collector = collectors.AptosCollector
+                case "tron", "tron":
+                    collector = collectors.TronCollector
                 case "evm", other:  # pylint: disable=unused-variable
                     collector = collectors.EvmCollector
             if collector is None:

--- a/src/test_registries.py
+++ b/src/test_registries.py
@@ -140,6 +140,17 @@ class TestCollectorRegistry(TestCase):
             helper_test_collector_registry(self, collector)
 
     @mock.patch.dict(os.environ, {
+        "CONFIG_FILE_PATH": "tests/fixtures/configuration_tron.yaml",
+        "VALIDATION_FILE_PATH": "tests/fixtures/validation.yaml"
+    })
+    def test_get_collector_registry_for_tron(self):
+        """Tests that the Tron collector is called with the correct args"""
+        self.collector_registry = CollectorRegistry()
+        with mock.patch('collectors.TronCollector', new=mock.Mock()) as collector:
+            helper_test_collector_registry(self, collector)
+
+
+    @mock.patch.dict(os.environ, {
         "CONFIG_FILE_PATH": "tests/fixtures/configuration_evm.yaml",
         "VALIDATION_FILE_PATH": "tests/fixtures/validation.yaml"
     })

--- a/src/tests/fixtures/configuration_tron.yaml
+++ b/src/tests/fixtures/configuration_tron.yaml
@@ -1,0 +1,12 @@
+blockchain: "Tron"
+chain_id: 1234
+network_name: "Testnet"
+network_type: "Testnet"
+collector: "tron"
+endpoints:
+  - url: https://test1.com
+    provider: TestProvider1
+  - url: https://test2.com
+    provider: TestProvider2
+  - url: https://test3.com
+    provider: TestProvider3


### PR DESCRIPTION
Added Tron Collector and relevant tests
To verify this exporter working, please setup as below:

Content for: config/exporter_example/config.yml

```
blockchain: "Tron"
network_name: "Testnet"
network_type: "Testnet"
collector: "tron"
endpoints:
  - url: https://docs-demo.tron-mainnet.quiknode.pro/jsonrpc
    provider: Public
```

Content for: config/exporter_example/validation.yml

```
allowed_providers:
  - Public
```

Then follow the instruction in README.md as below:
```
export CONFIG_FILE_PATH="config/exporter_example/config.yml"
export VALIDATION_FILE_PATH="config/exporter_example/validation.yml"
```

docker-compose up -d --build

curl localhost:8000/metrics # Exporter - can view in web UI too
curl localhost:3000         # Grafana - can view in web UI too
curl localhost:9090         # Prometheus - can view in web UI too