### PR TITLE
Add network_status metric and canonical_name labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ local*
 # Python
 venv
 __pycache__
+.coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
 prometheus-client==0.13.1
-pyyaml==6.0
+pyyaml==6.0.1
 schema==0.7.5
 websockets==10.4
 structlog==22.1.0

--- a/src/collectors.py
+++ b/src/collectors.py
@@ -5,9 +5,10 @@ from helpers import validate_dict_and_return_key_value, strip_url
 class EvmCollector():
     """A collector to fetch information about evm compatible RPC endpoints."""
 
-    def __init__(self, url, labels, chain_id, **client_parameters):
+    def __init__(self, url, labels, chain_id, network_status, **client_parameters):
         self.labels = labels
         self.chain_id = chain_id
+        self.network_status = network_status
 
         sub_payload = {
             "method": 'eth_subscribe',
@@ -58,9 +59,10 @@ class EvmCollector():
 class ConfluxCollector():
     """A collector to fetch information about conflux RPC endpoints."""
 
-    def __init__(self, url, labels, chain_id, **client_parameters):
+    def __init__(self, url, labels, chain_id, network_status, **client_parameters):
         self.labels = labels
         self.chain_id = chain_id
+        self.network_status = network_status
 
         sub_payload = {
             "method": 'cfx_subscribe',
@@ -111,9 +113,10 @@ class ConfluxCollector():
 class CardanoCollector():
     """A collector to fetch information about cardano RPC endpoints."""
 
-    def __init__(self, url, labels, chain_id, **client_parameters):
+    def __init__(self, url, labels, chain_id, network_status, **client_parameters):
         self.labels = labels
         self.chain_id = chain_id
+        self.network_status = network_status
         self.block_height_payload = {
             "id": "exporter",
             "jsonrpc": "2.0",
@@ -140,10 +143,11 @@ class CardanoCollector():
 class BitcoinCollector():
     """A collector to fetch information about Bitcoin RPC endpoints."""
 
-    def __init__(self, url, labels, chain_id, **client_parameters):
+    def __init__(self, url, labels, chain_id, network_status, **client_parameters):
 
         self.labels = labels
         self.chain_id = chain_id
+        self.network_status = network_status
         self.interface = HttpsInterface(url, client_parameters.get('open_timeout'),
                                         client_parameters.get('ping_timeout'))
         self._logger_metadata = {
@@ -209,10 +213,11 @@ class BitcoinCollector():
 class FilecoinCollector():
     """A collector to fetch information about filecoin RPC endpoints."""
 
-    def __init__(self, url, labels, chain_id, **client_parameters):
+    def __init__(self, url, labels, chain_id, network_status, **client_parameters):
 
         self.labels = labels
         self.chain_id = chain_id
+        self.network_status = network_status
         self.interface = HttpsInterface(url, client_parameters.get('open_timeout'),
                                         client_parameters.get('ping_timeout'))
         self._logger_metadata = {
@@ -264,14 +269,19 @@ class FilecoinCollector():
         """Returns connection latency."""
         return self.interface.latest_query_latency
 
+    def network_status(self):
+        """Returns network status."""
+        return self.interface.network_status
+
 
 class SolanaCollector():
     """A collector to fetch information about solana RPC endpoints."""
 
-    def __init__(self, url, labels, chain_id, **client_parameters):
+    def __init__(self, url, labels, chain_id, network_status, **client_parameters):
 
         self.labels = labels
         self.chain_id = chain_id
+        self.network_status = network_status
         self.interface = HttpsInterface(url, client_parameters.get('open_timeout'),
                                         client_parameters.get('ping_timeout'))
         self._logger_metadata = {
@@ -321,10 +331,11 @@ class SolanaCollector():
 class StarknetCollector():
     """A collector to fetch information about starknet RPC endpoints."""
 
-    def __init__(self, url, labels, chain_id, **client_parameters):
+    def __init__(self, url, labels, chain_id, network_status, **client_parameters):
 
         self.labels = labels
         self.chain_id = chain_id
+        self.network_status = network_status
         self.interface = HttpsInterface(url, client_parameters.get('open_timeout'),
                                         client_parameters.get('ping_timeout'))
 
@@ -356,10 +367,11 @@ class StarknetCollector():
 class AptosCollector():
     """A collector to fetch information about Aptos endpoints."""
 
-    def __init__(self, url, labels, chain_id, **client_parameters):
+    def __init__(self, url, labels, chain_id, network_status, **client_parameters):
 
         self.labels = labels
         self.chain_id = chain_id
+        self.network_status = network_status
         self.interface = HttpsInterface(url, client_parameters.get('open_timeout'),
                                         client_parameters.get('ping_timeout'))
 

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -57,6 +57,10 @@ class Config():
             And(int),
             'network_name':
             And(str),
+            'canonical_name':
+            And(str),
+            'network_status':
+            And(str),
             'network_type':
             And(str, lambda s: s in ('Testnet', 'Mainnet')),
             'collector':

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -12,7 +12,7 @@ class MetricsLoader():
     def __init__(self):
         self._labels = [
             'url', 'provider', 'blockchain', 'network_name', 'network_type',
-            'evmChainID'
+            'evmChainID', 'canonical_name'
         ]
 
     @property
@@ -51,6 +51,14 @@ class MetricsLoader():
             'brpc_client_version',
             'Client version for the particular RPC endpoint.',
             labels=self._labels)
+    
+    @property
+    def network_status_metric(self):
+        """Returns instantiated network status metric."""
+        return InfoMetricFamily(
+            'brpc_network_status',
+            'Network status - live, preview, degraded',
+            labels=['canonical_name', 'status'])
 
     @property
     def total_difficulty_metric(self):
@@ -126,6 +134,7 @@ class PrometheusCustomCollector():  # pylint: disable=too-few-public-methods
         disconnects_metric = self._metrics_loader.disconnects_metric
         block_height_metric = self._metrics_loader.block_height_metric
         client_version_metric = self._metrics_loader.client_version_metric
+        network_status_metric = self._metrics_loader.network_status_metric
         total_difficulty_metric = self._metrics_loader.total_difficulty_metric
         latency_metric = self._metrics_loader.latency_metric
         block_height_delta_metric = self._metrics_loader.block_height_delta_metric
@@ -149,6 +158,7 @@ class PrometheusCustomCollector():  # pylint: disable=too-few-public-methods
                                 total_difficulty_metric, 'total_difficulty')
         for collector in self._collector_registry:
             self._write_metric(collector, latency_metric, 'latency')
+            self._write_metric(collector, network_status_metric, 'network_status')
         self.delta_compared_to_max(
             block_height_metric, block_height_delta_metric)
         self.delta_compared_to_max(
@@ -161,5 +171,6 @@ class PrometheusCustomCollector():  # pylint: disable=too-few-public-methods
         yield client_version_metric
         yield total_difficulty_metric
         yield latency_metric
+        yield network_status_metric
         yield block_height_delta_metric
         yield difficulty_delta_metric

--- a/src/registries.py
+++ b/src/registries.py
@@ -10,12 +10,14 @@ class Endpoint():  # pylint: disable=too-few-public-methods
     """RPC Endpoint class, to store metadata."""
 
     def __init__(  # pylint: disable=too-many-arguments
-            self, url, provider, blockchain, network_name, network_type,
+            self, url, provider, blockchain, network_name, canonical_name, network_type, network_status,
             chain_id, **client_parameters):
         self.url = url
         self.chain_id = chain_id
+        self.canonical_name = canonical_name
+        self.network_status = network_status
         self.labels = [
-            url, provider, blockchain, network_name, network_type,
+            url, provider, blockchain, network_name, network_type, canonical_name,
             str(chain_id)
         ]
         self.client_parameters = client_parameters
@@ -50,6 +52,8 @@ class EndpointRegistry(Config):
                          self.blockchain,
                          self.get_property('network_name'),
                          self.get_property('network_type'),
+                         self.get_property('network_status'),
+                         self.get_property('canonical_name'),
                          self.get_property('chain_id'),
                          **self.client_parameters))
         return endpoints_list
@@ -96,5 +100,6 @@ class CollectorRegistry(EndpointRegistry):
             else:
                 collectors_list.append(collector(item.url,
                                                  item.labels, item.chain_id,
+                                                 item.network_status,
                                                  **self.client_parameters))
         return collectors_list

--- a/src/test_collectors.py
+++ b/src/test_collectors.py
@@ -12,6 +12,7 @@ class TestEvmCollector(TestCase):
         self.url = "wss://test.com"
         self.labels = ["dummy", "labels"]
         self.chain_id = 123
+        self.network_status = "live"
         self.client_params = {"param1": "dummy", "param2": "data"}
         self.sub_payload = {
             "method": 'eth_subscribe',
@@ -21,7 +22,7 @@ class TestEvmCollector(TestCase):
         }
         with mock.patch('collectors.WebsocketInterface') as mocked_websocket:
             self.evm_collector = collectors.EvmCollector(
-                self.url, self.labels, self.chain_id, **self.client_params)
+                self.url, self.labels, self.chain_id, self.network_status, **self.client_params)
             self.mocked_websocket = mocked_websocket
 
     def test_websocket_interface_created(self):
@@ -99,6 +100,7 @@ class TestConfluxCollector(TestCase):
         self.url = "wss://test.com"
         self.labels = ["dummy", "labels"]
         self.chain_id = 123
+        self.network_status = "live"
         self.client_params = {"param1": "dummy", "param2": "data"}
         self.sub_payload = {
             "method": 'cfx_subscribe',
@@ -108,7 +110,7 @@ class TestConfluxCollector(TestCase):
         }
         with mock.patch('collectors.WebsocketInterface') as mocked_websocket:
             self.conflux_collector = collectors.ConfluxCollector(
-                self.url, self.labels, self.chain_id, **self.client_params)
+                self.url, self.labels, self.chain_id, self.network_status, **self.client_params)
             self.mocked_websocket = mocked_websocket
 
     def test_websocket_interface_created(self):
@@ -186,6 +188,7 @@ class TestCardanoCollector(TestCase):
         self.url = "wss://test.com"
         self.labels = ["dummy", "labels"]
         self.chain_id = 123
+        self.network_status = "live"
         self.client_params = {"param1": "dummy", "param2": "data"}
         self.block_height_payload = {
             "id": "exporter",
@@ -194,7 +197,7 @@ class TestCardanoCollector(TestCase):
         }
         with mock.patch('collectors.WebsocketInterface') as mocked_websocket:
             self.cardano_collector = collectors.CardanoCollector(
-                self.url, self.labels, self.chain_id, **self.client_params)
+                self.url, self.labels, self.chain_id, self.network_status, **self.client_params)
             self.mocked_websocket = mocked_websocket
 
     def test_websocket_interface_created(self):
@@ -242,6 +245,7 @@ class TestBitcoinCollector(TestCase):
         self.url = "wss://test.com"
         self.labels = ["dummy", "labels"]
         self.chain_id = 123
+        self.network_status = "live"
         self.open_timeout = 8
         self.ping_timeout = 9
         self.client_params = {
@@ -259,7 +263,7 @@ class TestBitcoinCollector(TestCase):
         }
         with mock.patch('collectors.HttpsInterface') as mocked_connection:
             self.bitcoin_collector = collectors.BitcoinCollector(
-                self.url, self.labels, self.chain_id, **self.client_params)
+                self.url, self.labels, self.chain_id, self.network_status, **self.client_params)
             self.mocked_connection = mocked_connection
 
     def test_logger_metadata(self):
@@ -384,6 +388,7 @@ class TestFilecoinCollector(TestCase):
         self.url = "wss://test.com"
         self.labels = ["dummy", "labels"]
         self.chain_id = 123
+        self.network_status = "live"
         self.open_timeout = 8
         self.ping_timeout = 9
         self.client_params = {
@@ -400,7 +405,7 @@ class TestFilecoinCollector(TestCase):
         }
         with mock.patch('collectors.HttpsInterface') as mocked_connection:
             self.filecoin_collector = collectors.FilecoinCollector(
-                self.url, self.labels, self.chain_id, **self.client_params)
+                self.url, self.labels, self.chain_id, self.network_status, **self.client_params)
             self.mocked_connection = mocked_connection
 
     def test_logger_metadata(self):
@@ -498,6 +503,7 @@ class TestSolanaCollector(TestCase):
         self.url = "wss://test.com"
         self.labels = ["dummy", "labels"]
         self.chain_id = 123
+        self.network_status = "live"
         self.open_timeout = 8
         self.ping_timeout = 9
         self.client_params = {
@@ -514,7 +520,7 @@ class TestSolanaCollector(TestCase):
         }
         with mock.patch('collectors.HttpsInterface') as mocked_connection:
             self.solana_collector = collectors.SolanaCollector(
-                self.url, self.labels, self.chain_id, **self.client_params)
+                self.url, self.labels, self.chain_id, self.network_status, **self.client_params)
             self.mocked_connection = mocked_connection
 
     def test_logger_metadata(self):
@@ -598,6 +604,7 @@ class TestStarknetCollector(TestCase):
         self.url = "wss://test.com"
         self.labels = ["dummy", "labels"]
         self.chain_id = 123
+        self.network_status = "live"
         self.open_timeout = 8
         self.ping_timeout = 9
         self.client_params = {
@@ -609,7 +616,7 @@ class TestStarknetCollector(TestCase):
         }
         with mock.patch('collectors.HttpsInterface') as mocked_connection:
             self.starknet_collector = collectors.StarknetCollector(
-                self.url, self.labels, self.chain_id, **self.client_params)
+                self.url, self.labels, self.chain_id, self.network_status, **self.client_params)
             self.mocked_connection = mocked_connection
 
     def test_https_interface_created(self):
@@ -658,13 +665,14 @@ class TestAptosCollector(TestCase):
         self.url = "https://test.com"
         self.labels = ["dummy", "labels"]
         self.chain_id = 123
+        self.network_status = "live"
         self.open_timeout = 8
         self.ping_timeout = 9
         self.client_params = {
             "open_timeout": self.open_timeout, "ping_timeout": self.ping_timeout}
         with mock.patch('collectors.HttpsInterface') as mocked_connection:
             self.aptos_collector = collectors.AptosCollector(
-                self.url, self.labels, self.chain_id, **self.client_params)
+                self.url, self.labels, self.chain_id, self.network_status, **self.client_params)
             self.mocked_connection = mocked_connection
 
     def test_logger_metadata(self):

--- a/src/test_configuration.py
+++ b/src/test_configuration.py
@@ -44,10 +44,14 @@ class TestConfiguration(TestCase):
         expected_configuration = {
             "blockchain":
             "TestChain",
+            "canonical_name":
+            "canonical_name",
             "chain_id":
             1234,
             "network_name":
             "TestNetwork",
+            "network_status":
+            "live",
             "network_type":
             "Mainnet",
             "collector":

--- a/src/test_registries.py
+++ b/src/test_registries.py
@@ -17,10 +17,12 @@ class TestEndpoint(TestCase):  # pylint: disable=too-many-instance-attributes
         self.blockchain = "test_chain"
         self.network_name = "test_network"
         self.network_type = "ETH"
+        self.network_status = "live"
+        self.canonical_name = "canonical_name"
         self.chain_id = 123
         self.client_params = {"dummy": "data"}
         self.endpoint = Endpoint(self.url, self.provider, self.blockchain,
-                                 self.network_name, self.network_type,
+                                 self.network_name, self.canonical_name, self.network_type, self.network_status,
                                  self.chain_id, **self.client_params)
 
     def test_url_attribute(self):
@@ -34,7 +36,7 @@ class TestEndpoint(TestCase):  # pylint: disable=too-many-instance-attributes
     def test_labels_attribute(self):
         """Tests the labels attribute is set correctly"""
         labels = [self.url, self.provider, self.blockchain,
-                  self.network_name, self.network_type, str(self.chain_id)]
+                  self.network_name, self.network_type, self.canonical_name, str(self.chain_id)]
         self.assertEqual(labels, self.endpoint.labels)
 
 
@@ -213,6 +215,6 @@ def helper_test_collector_registry(test_collector_registry, mock_collector):
         all(isinstance(col, mock.Mock) for col in collector_list))
     calls = []
     for item in test_collector_registry.collector_registry.get_endpoint_registry:
-        calls.append(mock.call(item.url, item.labels, item.chain_id,
+        calls.append(mock.call(item.url, item.labels, item.chain_id, item.network_status,
                      **test_collector_registry.collector_registry.client_parameters))
     mock_collector.assert_has_calls(calls, False)

--- a/src/tests/fixtures/configuration.yaml
+++ b/src/tests/fixtures/configuration.yaml
@@ -1,7 +1,9 @@
 blockchain: "TestChain"
 chain_id: 1234
 network_name: "TestNetwork"
+canonical_name: canonical_name
 network_type: "Mainnet"
+network_status: live
 collector: "evm"
 endpoints:
   - url: wss://test1.com

--- a/src/tests/fixtures/configuration_aptos.yaml
+++ b/src/tests/fixtures/configuration_aptos.yaml
@@ -1,7 +1,9 @@
 blockchain: "Aptos"
 chain_id: 1234
 network_name: "Testnet"
+canonical_name: canonical_name
 network_type: "Testnet"
+network_status: live
 collector: "aptos"
 endpoints:
   - url: https://test1.com

--- a/src/tests/fixtures/configuration_bitcoin.yaml
+++ b/src/tests/fixtures/configuration_bitcoin.yaml
@@ -1,7 +1,9 @@
 blockchain: "Bitcoin"
 chain_id: 1234
 network_name: "TestNetwork"
+canonical_name: canonical_name
 network_type: "Mainnet"
+network_status: live
 collector: "bitcoin"
 endpoints:
   - url: wss://test1.com

--- a/src/tests/fixtures/configuration_cardano.yaml
+++ b/src/tests/fixtures/configuration_cardano.yaml
@@ -1,7 +1,9 @@
 blockchain: "cardano"
 chain_id: 1234
 network_name: "TestNetwork"
+canonical_name: canonical_name
 network_type: "Mainnet"
+network_status: live
 collector: "cardano"
 endpoints:
   - url: wss://test1.com

--- a/src/tests/fixtures/configuration_conflux.yaml
+++ b/src/tests/fixtures/configuration_conflux.yaml
@@ -1,7 +1,9 @@
 blockchain: "conflux"
 chain_id: 1234
 network_name: "TestNetwork"
+canonical_name: canonical_name
 network_type: "Mainnet"
+network_status: live
 collector: "conflux"
 endpoints:
   - url: wss://test1.com

--- a/src/tests/fixtures/configuration_conn_params.yaml
+++ b/src/tests/fixtures/configuration_conn_params.yaml
@@ -1,7 +1,9 @@
 blockchain: "TestChain"
 chain_id: 1234
 network_name: "TestNetwork"
+canonical_name: canonical_name
 network_type: "Mainnet"
+network_status: live
 collector: "evm"
 connection_parameters:
   open_timeout: 1

--- a/src/tests/fixtures/configuration_evm.yaml
+++ b/src/tests/fixtures/configuration_evm.yaml
@@ -2,6 +2,8 @@ blockchain: "other"
 chain_id: 1234
 network_name: "TestNetwork"
 network_type: "Mainnet"
+network_status: live
+canonical_name: canonical_name
 collector: "evm"
 endpoints:
   - url: wss://test1.com

--- a/src/tests/fixtures/configuration_filecoin.yaml
+++ b/src/tests/fixtures/configuration_filecoin.yaml
@@ -1,7 +1,9 @@
 blockchain: "filecoin"
 chain_id: 1234
 network_name: "TestNetwork"
+canonical_name: canonical_name
 network_type: "Mainnet"
+network_status: live
 collector: "filecoin"
 endpoints:
   - url: wss://test1.com

--- a/src/tests/fixtures/configuration_invalid.yaml
+++ b/src/tests/fixtures/configuration_invalid.yaml
@@ -1,7 +1,9 @@
 blockchain: "TestChain"
 chain_id: '1234' # str instead of int
 network_name: "TestNetwork"
+canonical_name: canonical_name
 network_type: "Mainnet"
+network_status: live
 collector: "evm"
 endpoints:
   - url: wss://test1.com

--- a/src/tests/fixtures/configuration_solana.yaml
+++ b/src/tests/fixtures/configuration_solana.yaml
@@ -1,7 +1,9 @@
 blockchain: "solana"
 chain_id: 1234
 network_name: "TestNetwork"
+canonical_name: canonical_name
 network_type: "Mainnet"
+network_status: live
 collector: "solana"
 endpoints:
   - url: wss://test1.com

--- a/src/tests/fixtures/configuration_starknet.yaml
+++ b/src/tests/fixtures/configuration_starknet.yaml
@@ -1,7 +1,9 @@
 blockchain: "starknet"
 chain_id: 1234
 network_name: "TestNetwork"
+canonical_name: canonical_name
 network_type: "Mainnet"
+network_status: live
 collector: "starknet"
 endpoints:
   - url: wss://test1.com

--- a/src/tests/fixtures/configuration_tron.yaml
+++ b/src/tests/fixtures/configuration_tron.yaml
@@ -1,7 +1,9 @@
 blockchain: "Tron"
 chain_id: 1234
 network_name: "Testnet"
+canonical_name: canonical_name
 network_type: "Testnet"
+network_status: live
 collector: "tron"
 endpoints:
   - url: https://test1.com

--- a/src/tests/fixtures/configuration_unsupported_blockchain.yaml
+++ b/src/tests/fixtures/configuration_unsupported_blockchain.yaml
@@ -1,7 +1,9 @@
 blockchain: "bitcoin"
 chain_id: 1234
 network_name: "TestNetwork"
+canonical_name: canonical_name
 network_type: "Mainnet"
+network_status: live
 collector: "cardano"
 endpoints:
   - url: wss://test1.com


### PR DESCRIPTION
* canonical_name is the preffered method of linking stuff to chains
* network_status is a (WIP) metric to determine network "tier" or status, meaning: live (production, users) or preview (working on it) so you can drive your alerting needs based on it

network_status is derived from config (via rpc inventory in infra-k8s). 

Also fixes build on python 3.12