### PR TITLE
remove provider validation

### DIFF
--- a/config/exporter_example/validation.yml
+++ b/config/exporter_example/validation.yml
@@ -1,5 +1,0 @@
-# To enforce uniform labels in your metrics, we need to limit what providers and blockchains users can specify in their exporter configuration.
-allowed_providers: # When adding endpoints, these are the only values you will be able to add as providers. Otherwise program will exit with error.
-  - Provider1
-  - Provider2
-  - Provider3

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -15,8 +15,6 @@ class Config():
         self._logger_metadata = {'component': 'Config'}
         self.configuration_file_path = os.getenv('CONFIG_FILE_PATH',
                                                  default='/config/config.yml')
-        self.validation_file_path = os.getenv('VALIDATION_FILE_PATH',
-                                              default='/config/validation.yml')
         self._configuration = self._load_configuration()
 
     def get_property(self, property_name):
@@ -45,7 +43,6 @@ class Config():
         return self.get_property('endpoints')
 
     def _load_configuration(self):
-        allowed_providers = self._load_validation_file()
         supported_collectors = ('evm', 'evmhttp', 'cardano', 'conflux', 'solana',
                                 'bitcoin', 'doge', 'filecoin', 'starknet', 'aptos',
                                 'tron')
@@ -77,18 +74,11 @@ class Config():
                 'url':
                 And(str, Regex('https://.*|wss://.*|ws://.*')),
                 'provider':
-                And(str, lambda s: s in allowed_providers)
+                And(str)
             }]
         })
         return self._load_and_validate(self.configuration_file_path,
                                        configuration_schema)
-
-    def _load_validation_file(self):
-
-        validation_schema = Schema({'allowed_providers': [And(str)]})
-        return self._load_and_validate(
-            self.validation_file_path,
-            validation_schema).get('allowed_providers')
 
     def _load_and_validate(self, path: str, schema: Schema) -> dict:
         """Loads file from path as yaml and validates against provided schema."""

--- a/src/test_configuration.py
+++ b/src/test_configuration.py
@@ -10,15 +10,12 @@ from configuration import Config
 CONFIG_FILES = {"valid": "tests/fixtures/configuration.yaml",
                 "invalid": "tests/fixtures/configuration_invalid.yaml",
                 "client_params": "tests/fixtures/configuration_conn_params.yaml"}
-VALIDATION_FILES = {"valid": "tests/fixtures/validation.yaml"}
 
-
-def setup_config_object(config_file, validation_file) -> Config:
-    """Creates a Config object using the provided config and validation files"""
+def setup_config_object(config_file) -> Config:
+    """Creates a Config object using the provided config files"""
     with mock.patch.dict(
             os.environ, {
                 "CONFIG_FILE_PATH": config_file,
-                "VALIDATION_FILE_PATH": validation_file
             }):
         return Config()
 
@@ -30,9 +27,9 @@ class TestConfiguration(TestCase):
         """Set up dummy configs for us."""
         self.maxDiff = None
         self.config = setup_config_object(
-            CONFIG_FILES["valid"], VALIDATION_FILES["valid"])
+            CONFIG_FILES["valid"])
         self.client_params_config = setup_config_object(
-            CONFIG_FILES["client_params"], VALIDATION_FILES["valid"])
+            CONFIG_FILES["client_params"])
 
     def test_invalid_get_property(self):
         """Tests getting invalid properties returns None type"""
@@ -113,7 +110,7 @@ class TestConfiguration(TestCase):
         """Tests that the program exits when loading a configuration file with a schema exception"""
         with self.assertRaises(SystemExit) as cm:
             setup_config_object(
-                CONFIG_FILES["invalid"], VALIDATION_FILES["valid"])
+                CONFIG_FILES["invalid"])
         self.assertEqual(1, cm.exception.code)
 
     def test_load_and_validate_schema_exception_error_log(self):
@@ -121,7 +118,7 @@ class TestConfiguration(TestCase):
         try:
             with capture_logs() as captured:
                 setup_config_object(
-                    CONFIG_FILES["invalid"], VALIDATION_FILES["valid"])
+                    CONFIG_FILES["invalid"])
         except SystemExit:
             # Catch and pass on expected SystemExit so tests keep running
             pass
@@ -132,7 +129,7 @@ class TestConfiguration(TestCase):
         try:
             with capture_logs() as captured:
                 setup_config_object(
-                    CONFIG_FILES["valid"], VALIDATION_FILES["valid"])
+                    CONFIG_FILES["valid"])
         except SystemExit:
             # Catch and pass on expected SystemExit so tests keep running
             pass

--- a/src/tests/fixtures/validation.yaml
+++ b/src/tests/fixtures/validation.yaml
@@ -1,4 +1,0 @@
-allowed_providers:
-  - TestProvider1
-  - TestProvider2
-  - TestProvider3


### PR DESCRIPTION
- we use rpc-inventory to guarantee consistency across naming
- this introduced friction when managing providers and building OneClick / crib automation around this app